### PR TITLE
Feature/cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,12 +208,15 @@ jobs:
           # token: ${{ secrets.GITHUB_TOKEN }}
           # rules_file_name: '.zap/rules.tsv'
 
+      - name: List ZAP Scan Artifacts
+        run: ls -l
+
       - name: Upload ZAP Report for ${{ matrix.image }}
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: zap-scan-${{ matrix.image }}
-          path: zap-scan-${{ matrix.image }}
+          path: zap-scan-${{ matrix.image }}.zip
 
   sign_and_sbom:
     needs: [dast]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,23 +200,13 @@ jobs:
         uses: zaproxy/action-baseline@v0.11.0
         with:
           target: ${{ steps.set_target.outputs.TARGET }}
-          allow_issue_writing: true
+          allow_issue_writing: false # Set to true to allow the action to write the results as an issue
           docker_name: 'ghcr.io/zaproxy/zaproxy:20231218-stable' # zaproxy:20240103-stable breaks due to https://github.com/zaproxy/action-full-scan/issues/39
           artifact_name: zap-scan-${{ matrix.image }}
           # fail_action: ${{ steps.fail_action.outputs.FAIL_ACTION }}
           # cmd_options: '-d' # '-d' is for debug mode
           # token: ${{ secrets.GITHUB_TOKEN }}
           # rules_file_name: '.zap/rules.tsv'
-
-      - name: List ZAP Scan Artifacts
-        run: ls -l
-
-      - name: Upload ZAP Report for ${{ matrix.image }}
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zap-scan-${{ matrix.image }}
-          path: zap-scan-${{ matrix.image }}.zip
 
   sign_and_sbom:
     needs: [dast]


### PR DESCRIPTION
## Changes
- Removed `upload-artifact` step after OWASP scan because the default behavior of the `zap-baseline` action seems to upload the .zip artifact to the workflow run.